### PR TITLE
fix: permissions of PR review action

### DIFF
--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -12,6 +12,8 @@ jobs:
     name: Approved
     if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Add Reviewed-By
         uses: ntessore/add-reviewed-by-action@v1


### PR DESCRIPTION
Add the necessary `pull-requests: write` permission to the PR review action.